### PR TITLE
Adding documentation for Hamilton, ON, Canada

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Waste collection schedules in the following formats and countries are supported.
 - [Calgary, AB](/doc/ics/recollect.md) / calgary.ca
 - [City of Edmonton, AB](/doc/ics/recollect.md) / edmonton.ca
 - [City of Greater Sudbury, ON](/doc/ics/recollect.md) / greatersudbury.ca
+- [Hamilton (ON)](/doc/source/recyclecoach_com.md) / hamilton.ca
 - [London (ON)](/doc/source/recyclecoach_com.md) / london.ca
 - [Ottawa, Canada](/doc/ics/recollect.md) / ottawa.ca
 - [RM of Morris, MB](/doc/ics/recollect.md) / mwmenviro.ca

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/recyclecoach_com.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/recyclecoach_com.py
@@ -37,6 +37,7 @@ EXTRA_INFO = [
         "url": "https://recyclecoach.com/cities/usa-ky-city-of-louisville/",
     },
     {"title": "London (ON)", "url": "https://london.ca/", "country": "ca"},
+    {"title": "Hamilton (ON)", "url": "https://hamilton.ca/", "country": "ca"},
 ]
 
 TEST_CASES = {


### PR DESCRIPTION
Hamilton, ON, Canada uses RecycleCoach.com which is already available in the repo.

This PR only adds documentation to both `README` and `recyclecoach_com.py` to make it easier for users to know the Canadian city is supported by [hacs_waste_collection_schedule](https://github.com/5ila5/hacs_waste_collection_schedule).